### PR TITLE
修复Hall Print 版式版头的异常宽度。

### DIFF
--- a/New_BHL/hallprint.scss
+++ b/New_BHL/hallprint.scss
@@ -110,7 +110,7 @@
 /* Header Wallpaper */
 #skrollr-body {
     height: var(--header-height-on-desktop);
-    width: 100vw;
+    width: 100%;
 
     &::before {
         content: "";


### PR DESCRIPTION
#skrollr-body {
  width: 100vw → 100%;
}